### PR TITLE
Update dependencies (part 2) - plugins/test/gradle dsl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'jacoco'
     id 'io.spring.dependency-management' version '1.0.8.RELEASE'
     id 'org.springframework.boot' version '2.1.5.RELEASE'
-    id 'org.owasp.dependencycheck' version '4.0.2'
+    id 'org.owasp.dependencycheck' version '5.0.0'
     id 'com.jfrog.bintray' version '1.8.4'
     id 'java-library'
     id 'maven'

--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ bintray {
 }
 
 ext {
-    junitVersion = '5.3.2'
+    junitVersion = '5.4.2'
     githubFeignVersion = '10.2.3'
 }
 
@@ -177,26 +177,27 @@ dependencies {
 
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
 
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junitVersion
-    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: junitVersion
-    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: junitVersion
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: junitVersion
 
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'
     testCompile group: 'org.mockito', name: 'junit-jupiter', version: '2.20.0'
 
+    integrationTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: junitVersion
+
     integrationTestCompile sourceSets.main.runtimeClasspath
     integrationTestCompile sourceSets.test.runtimeClasspath
-    integrationTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
+    integrationTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
+        exclude group: 'junit', module: 'junit'
+    }
 }
 
-test {
+tasks.withType(Test) {
     useJUnitPlatform()
     failFast = true
-}
 
-integration {
-    useJUnitPlatform()
-    failFast = true
+    testLogging {
+        exceptionFormat = 'full'
+    }
 }
 
 bootJar {

--- a/build.gradle
+++ b/build.gradle
@@ -100,12 +100,12 @@ def pomConfig = {
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
+    archiveClassifier.set('sources')
     from sourceSets.main.allSource
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
     from javadoc.destinationDir
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,6 @@ bintray {
 }
 
 ext {
-    junitVersion = '5.4.2'
     githubFeignVersion = '10.2.3'
 }
 
@@ -170,23 +169,20 @@ dependencyManagement {
 }
 
 dependencies {
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.1.1.RELEASE'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.1.1.RELEASE'
 
-    compile group: 'io.github.openfeign', name: 'feign-jackson', version: githubFeignVersion
+    implementation group: 'io.github.openfeign', name: 'feign-jackson', version: githubFeignVersion
 
-    compile group: 'commons-io', name: 'commons-io', version: '2.6'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.6'
 
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: junitVersion
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.4.2'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.12.2'
+    testImplementation group: 'org.mockito', name: 'junit-jupiter', version: '2.20.0'
 
-    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.12.2'
-    testCompile group: 'org.mockito', name: 'junit-jupiter', version: '2.20.0'
-
-    integrationTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: junitVersion
-
-    integrationTestCompile sourceSets.main.runtimeClasspath
-    integrationTestCompile sourceSets.test.runtimeClasspath
-    integrationTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
+    integrationTestImplementation sourceSets.main.runtimeClasspath
+    integrationTestImplementation sourceSets.test.runtimeClasspath
+    integrationTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
         exclude group: 'junit', module: 'junit'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ dependencies {
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: junitVersion
 
-    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'
+    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.12.2'
     testCompile group: 'org.mockito', name: 'junit-jupiter', version: '2.20.0'
 
     integrationTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: junitVersion


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Upgrade OWASP plugin in all projects](https://tools.hmcts.net/jira/browse/BPS-677)

### Change description ###

As mentioned in #18 this should have been dedicated for owasp only. But no complications found so extended to full dependency upgrade (what's left behind):

- OWASP plugin 4.0.2 -> 5.0.0
- junit 5.3.2 -> 5.4.2
- assertj 3.11.1 -> 3.12.2

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes - use of non transitive dependency decalaration
[x] No - code itself has not changed - library still operational as before
```
