### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,4 @@ script:
 
 after_success:
   - ./gradlew jacocoTestReport
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/hmcts/send-letter-client.svg?branch=master)](https://travis-ci.org/hmcts/send-letter-client)
+[![codecov](https://codecov.io/gh/hmcts/send-letter-client/branch/master/graph/badge.svg)](https://codecov.io/gh/hmcts/send-letter-client)
 [![Download](https://api.bintray.com/packages/hmcts/hmcts-maven/send-letter-client/images/download.svg) ](https://bintray.com/hmcts/hmcts-maven/send-letter-client/_latestVersion)
 
 # Send Letter Client

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '2.2.0'
+version '2.3.0'
 
 checkstyle {
     maxWarnings = 0


### PR DESCRIPTION
### Change description ###

No library dependencies are transported. Internally using latest dependencies. Jackson vulnerability resolved by bumping 2.9.8 -> 2.9.9

Bonus in this PR: codecov badge

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
