### PR TITLE
Only allow builds against master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+branches:
+  only:
+    - master
+
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/


### PR DESCRIPTION
### Change description ###

As per previous PR I've noticed travis build notification while creating PR. This should not be the case and only start builds when submitted a PR and once merge to master

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
