### PR TITLE
Bump client 2.5.0 -> 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the client library for the [send-letter-service](https://github.com/hmct
 ### Prerequisites
 
 - [JDK 8](https://www.oracle.com/java)
-- Project requires Spring Boot v2.1 to be present
+- Project requires Spring Boot v2.2 to be present
 
 ## Usage
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,10 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.27.0'
 }
 
+def buildNumber = '2.6.0'
+
 group 'uk.gov.hmcts.reform'
-version '2.5.0'
+version buildNumber
 
 checkstyle {
     maxWarnings = 0


### PR DESCRIPTION
### Change description ###

#32 not yet ready so have to do manually for now. Bumping to next major release number because #33 contained significant version jump for `feign-jackson` dependency. And `openfeign` client `2.1 -> 2.2` migration happened as well.

Using `buildNumber` to minify #32 (one line but still 🤷‍♂ )

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
