### PR TITLE
FACT 1698 - Renovate Dependency Updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ version buildNumber
 
 checkstyle {
     maxWarnings = 0
-    toolVersion = '10.12.1'
+    toolVersion = '10.15.0'
 }
 
 dependencyUpdates.resolutionStrategy {

--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,7 @@ dependencies {
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.25.3'
 
     testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.10.0'
-    testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8-standalone', version: '2.35.0'
+    testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8-standalone', version: '2.35.1'
 
     integrationTestImplementation sourceSets.main.runtimeClasspath
     integrationTestImplementation sourceSets.test.runtimeClasspath


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-1698

### Change description ###

All relevant Renovate dependencies have been merged into this PR.

**Major Version Jumps:**

- wiremock-jre8-standalone 2.x to 3.x

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
